### PR TITLE
'?' not appended for metadata and thumbnails

### DIFF
--- a/lib/dropbox-node.js
+++ b/lib/dropbox-node.js
@@ -139,7 +139,7 @@ DropboxClient.prototype.putFile = function(file, path, optargs, cb) {
 DropboxClient.prototype.getMetadata = function(path, optargs, cb) {
   if (typeof optargs == 'function') cb = optargs, optargs = {};
   path = escapePath(path);
-  this.oauth.get(API_URI + '/metadata/dropbox/' + path +
+  this.oauth.get(API_URI + '/metadata/dropbox/' + path + '?' +
                  stringifyParams(optargs)
                  , optargs.token || this.access_token
                  , optargs.secret || this.access_token_secret
@@ -156,7 +156,7 @@ DropboxClient.prototype.getMetadata = function(path, optargs, cb) {
 DropboxClient.prototype.getThumbnail = function(path, optargs, cb) {
   if (typeof optargs == 'function') cb = optargs, optargs = {};
   path = escapePath(path);
-  this.oauth.get(CONTENT_API_URI + '/thumbnails/dropbox/' + path +
+  this.oauth.get(CONTENT_API_URI + '/thumbnails/dropbox/' + path + '?' +
                  stringifyParams(optargs)
                  , optargs.token || this.access_token
                  , optargs.secret || this.access_token_secret


### PR DESCRIPTION
Likely since their paths are passed in.
