### PR TITLE
Connect middleware to handle web based OAuth authorization

### DIFF
--- a/lib/dropbox-node.js
+++ b/lib/dropbox-node.js
@@ -3,7 +3,8 @@ var querystring = require('querystring')
   , stringifyParams = require('./util/stringify-params')
   , OAuth = require('oauth').OAuth
   , API_URI = 'http://api.dropbox.com/0'
-  , CONTENT_API_URI = 'https://api-content.dropbox.com/0';
+  , CONTENT_API_URI = 'https://api-content.dropbox.com/0'
+  , AUTHORIZE_URI = 'http://www.dropbox.com/0/oauth/authorize';
 
 
 // Returns a Dropbox Client, through which API calls can be made.
@@ -42,6 +43,88 @@ DropboxClient.prototype.getAccessToken = function(email, pwd, cb) {
                  });
 }
 
+// Connect middleware to provide OAuth based authorization to Dropbox
+// on the specified path. Requires connect-session middleware.
+// After successful authorization, user's session will contain
+// access_token and access_token_secret
+DropboxClient.prototype.login = function(mount, success) {
+  var self = this
+    , url = require('url')
+    , mount = mount || '/dbauth';
+
+  return function handle(req, res, next) {
+    var path = url.parse(req.url, true);
+
+    // Only handle requests to the exact path
+    if(path.pathname !== mount) return next();
+
+    // Set the oauth_callback based on this request if we don't have it
+    if(!self.oauth._authorize_callback) {
+      var scheme = req.socket.secure ? "https://" : "http://"
+        , callback_uri = url.parse(scheme + req.headers.host + req.url, true);
+      self.oauth._authorize_callback = callback_uri.href;
+    }
+
+    // Get the info in the user's session
+    var dbauth = req.session.dbauth;
+
+    // User is already authenticated, but in the wrong place
+    if(dbauth && dbauth.access_token_secret) {
+      res.writeHead(302, {'Location': success || '/'});
+      res.end();
+      return;
+
+    // User is returning from Dropbox with oauth_token
+    } else if(path.query && path.query.oauth_token && path.query.uid
+              && dbauth && dbauth.oauth_token_secret) {
+      self.oauth.getOAuthAccessToken(
+              path.query.oauth_token, dbauth.oauth_token_secret
+            , path.query.oauth_verifier
+            , function(error, access_token, access_token_secret, params) {
+              if(error) {
+                return next(error);
+              } else {
+                req.session.dbauth = {
+                  uid: path.query.uid,
+                  access_token: access_token,
+                  access_token_secret: access_token_secret
+                };
+                res.writeHead(302, {'Location': success || '/'});
+                res.end();
+                return;
+              }
+            })
+    // Begin OAuth transaction if we have no session or access_token_secret
+    } else if(!(dbauth && dbauth.access_token_secret)) {
+      self.oauth.getOAuthRequestToken(
+              function(error, oauth_token, oauth_token_secret, params) {
+                if(error) {
+                  return next(error);
+                } else {
+                  req.session.dbauth = {
+                    oauth_token: oauth_token,
+                    oauth_token_secret: oauth_token_secret
+                  };
+                  res.writeHead(302, {
+                    'Location': AUTHORIZE_URI + '?'
+                      + stringifyParams({
+                        oauth_token: oauth_token,
+                        oauth_callback: self.oauth._authorize_callback
+                      })
+                  });
+                  res.end();
+                  return;
+                }
+              });
+    // Invalid data in session, clear session data and restart process
+    } else {
+      delete req.session.dbauth;
+      res.writeHead(302, {'Location': mount});
+      res.end();
+      return;
+    }
+  }
+}
 
 // Retrieves information about the user's account as a JSON response.
 DropboxClient.prototype.getAccountInfo = function(optargs, cb) {


### PR DESCRIPTION
As discussed, here is a connect-middleware (session based) that handles the web based OAuth authorization. It mounts a route on the specified path. When a user is getting that path, they will be redirected to Dropbox for authorization of the app. On successful authorization, Dropbox will redirect the user back to the same path, where we store the token and secret in the session.

I'm not crazy about the method used, as I feel a consumer of the dropbox library might want greater freedom on how to handle the oauth token/secret, so if you have any suggestions, I'd be happy to rewrite it. 
